### PR TITLE
Fix endless waiting due to failing hal_read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed possible endless loop during lr11xx crypto initialization.
+
 ## [1.5.2] - 2024-03-06
 
 ### Changed

--- a/drivers/radio/radio_drivers_hal/lr11xx_hal.c
+++ b/drivers/radio/radio_drivers_hal/lr11xx_hal.c
@@ -1,9 +1,9 @@
 
-#include <zephyr/types.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
 #include <zephyr/kernel.h>
+#include <zephyr/types.h>
 
 #include "lr11xx_hal.h"
 #include "lr11xx_hal_context.h"
@@ -186,6 +186,11 @@ lr11xx_hal_status_t lr11xx_hal_read(const void *context, const uint8_t *command,
 	const struct device *lr11xx_dev = (const struct device *)context;
 	const struct lr11xx_hal_context_cfg_t *lr11xx_cfg = lr11xx_dev->config;
 
+	/* When hal_read is called by lr11xx_crypto_restore_from_flash during LoRa initialization,
+	 * we sleep for 1 ms so we don't get stuck in an endless wait loop */
+	if ((command[0] == 0x05) && (command[1] == 0x0B)) {
+		k_sleep(K_MSEC(1));
+	}
 	prv_lr11xx_hal_check_device_ready(lr11xx_dev);
 	int ret;
 


### PR DESCRIPTION
## Description

This PR focuses on fixing an issue where failing to successfully hal_read on LoRa initialization resulted in endless waiting.

## Areas of interest for the reviewer

drivers/radio/radio_drivers_hal/lr11xx_hal.c

<!--- Which parts of the code should the code reviewer check?  -->

## After-review steps

<!--- Delete section or select one option -->

- I will merge PR by myself.

[style guidelines]:
https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md