### PR TITLE
New NCS versions compatibility fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed compatibility with Zephyr version 3.4.0 and up.
+
 ## [1.5.4] - 2024-04-18
 
 ### Fixed

--- a/drivers/radio/radio_drivers_hal/lr11xx_hal.c
+++ b/drivers/radio/radio_drivers_hal/lr11xx_hal.c
@@ -7,6 +7,7 @@
 
 #include "lr11xx_hal.h"
 #include "lr11xx_hal_context.h"
+#include "version.h"
 
 #define LR11XX_HAL_WAIT_ON_BUSY_TIMEOUT_SEC CONFIG_LR11XX_HAL_WAIT_ON_BUSY_TIMEOUT_SEC
 
@@ -69,7 +70,12 @@ static void prv_lr11xx_hal_check_device_ready(const struct device *dev)
 		prv_lr11xx_hal_wait_on_busy(&lr11xx_cfg->busy);
 	} else {
 		// Busy is HIGH in sleep mode, wake-up the device with a small glitch on NSS
+
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3, 4, 0)
+		const struct spi_cs_control *ctrl = &lr11xx_cfg->spi.config.cs;
+#else
 		const struct spi_cs_control *ctrl = lr11xx_cfg->spi.config.cs;
+#endif
 
 		gpio_pin_set_dt(&ctrl->gpio, 1);
 		gpio_pin_set_dt(&ctrl->gpio, 0);


### PR DESCRIPTION
Compatibility change for new NCS versions.

Zephyr changed API at some point, from my understanding at 3.4.0.